### PR TITLE
More configurability for events, sm_zombie_ammo improvements

### DIFF
--- a/addons/sourcemod/scripting/MyJailbreak/catch.sp
+++ b/addons/sourcemod/scripting/MyJailbreak/catch.sp
@@ -113,6 +113,8 @@ ConVar gc_bBeginSetV;
 ConVar gc_bBeginSetVW;
 ConVar gc_bTeleportSpawn;
 
+ConVar gc_fCTSpeed;
+
 // Extern Convars
 ConVar g_iTerrorForLR;
 
@@ -216,6 +218,8 @@ public void OnPluginStart()
 	gc_fSprintTime = AutoExecConfig_CreateConVar("sm_catch_sprint_time", "3.0", "Time in seconds the player will sprint", _, true, 1.0);
 	gc_bAllowLR = AutoExecConfig_CreateConVar("sm_catch_allow_lr", "0", "0 - disabled, 1 - enable LR for last round and end eventday", _, true, 0.0, true, 1.0);
 	gc_bKillLoser = AutoExecConfig_CreateConVar("sm_catch_kill_loser", "0", "0 - disabled, 1 - Kill loserteam on event end / not for sm_catch_allow_lr '1'", _, true, 0.0, true, 1.0);
+	
+	gc_fCTSpeed = AutoExecConfig_CreateConVar("sm_catch_ct_speed", "1.4", "Ratio for how fast the CT move", _, true, 0.8);
 
 	AutoExecConfig_ExecuteFile();
 	AutoExecConfig_CleanFile();
@@ -1458,7 +1462,7 @@ public Action Timer_StartEvent(Handle timer)
 
 		if (GetClientTeam(i) == CS_TEAM_CT)
 		{
-			SetEntPropFloat(i, Prop_Data, "m_flLaggedMovementValue", 1.4);
+			SetEntPropFloat(i, Prop_Data, "m_flLaggedMovementValue", gc_fCTSpeed.FloatValue);
 		}
 
 		SetEntityMoveType(i, MOVETYPE_WALK);

--- a/addons/sourcemod/scripting/MyJailbreak/hide.sp
+++ b/addons/sourcemod/scripting/MyJailbreak/hide.sp
@@ -174,7 +174,7 @@ public void OnPluginStart()
 	gc_bVote = AutoExecConfig_CreateConVar("sm_hide_vote", "1", "0 - disabled, 1 - allow player to vote for hide round", _, true, 0.0, true, 1.0);
 	gc_bFreezeHider = AutoExecConfig_CreateConVar("sm_hide_freezehider", "1", "0 - disabled, 1 - enable freeze hider when hidetime gone", _, true, 0.0, true, 1.0);
 	gc_bBlackout = AutoExecConfig_CreateConVar("sm_hide_blackout", "1", "0 - disabled, 1 - enable black out seekers screen on hide time", _, true, 0.0, true, 1.0);
-	gc_iTAgrenades = AutoExecConfig_CreateConVar("sm_hide_tagrenades", "3", "how many tagrenades a guard have?", _, true, 1.0);
+	gc_iTAgrenades = AutoExecConfig_CreateConVar("sm_hide_tagrenades", "3", "how many tagrenades a guard have?", _, true, 0.0);
 
 	gc_bBeginSetA = AutoExecConfig_CreateConVar("sm_hide_begin_admin", "1", "When admin set event (!sethide) = 0 - start event next round, 1 - start event current round", _, true, 0.0, true, 1.0);
 	gc_bBeginSetW = AutoExecConfig_CreateConVar("sm_hide_begin_warden", "1", "When warden set event (!sethide) = 0 - start event next round, 1 - start event current round", _, true, 0.0, true, 1.0);
@@ -810,7 +810,7 @@ public void Event_TA_Detonate(Event event, const char[] name, bool dontBroadcast
 			return;
 		}
 
-		if (g_iTA[target] != g_iMaxTA)
+		if (g_iTA[target] < g_iMaxTA)
 		{
 			GivePlayerItem(target, "weapon_tagrenade");
 			int g_iTAgot = (g_iMaxTA - g_iTA[target]);
@@ -1205,7 +1205,10 @@ void PrepareDay(bool thisround)
 		}
 		else if (GetClientTeam(i) == CS_TEAM_CT)
 		{
-			GivePlayerItem(i, "weapon_tagrenade");
+			if (gc_iTAgrenades.BoolValue) // same as gc_iTAgrenades.IntValue != 0
+			{
+				GivePlayerItem(i, "weapon_tagrenade");
+			}
 
 			if (gc_bBlackout.BoolValue)
 			{


### PR DESCRIPTION
- Added the "sm_catch_ct_speed" cvar
- The "sm_hide_tagrenades" cvar now allows 0 tagrenade.
- Fixed maps that set the ammo of a weapon to 1 or weird values for "sm_zombie_ammo 1" by giving ammo to the player when they equip a firearm.
- Added "sm_zombie_ammo 2" that uses a custom function to replenish ammo, because "sv_infinite_ammo 2" gave infinite nades.
- Modified a bit some timers to avoid having multiple instances of them running at the same time.