### PR TITLE
Removed an useless marker check

### DIFF
--- a/addons/sourcemod/scripting/MyJailbreak/Modules/Warden/marker.sp
+++ b/addons/sourcemod/scripting/MyJailbreak/Modules/Warden/marker.sp
@@ -235,14 +235,6 @@ void MarkerMenu(int client)
 		return;
 	}
 
-	float radius = 2*GetVectorDistance(g_fMarkerSetupEndOrigin, g_fMarkerSetupStartOrigin);
-	if (radius <= 0.0)
-	{
-		RemoveMarker(marker);
-		CPrintToChat(client, "%s %t", g_sPrefix, "warden_wrong");
-		return;
-	}
-
 	float g_fPos[3];
 	GetEntPropVector(client, Prop_Send, "m_vecOrigin", g_fPos);
 


### PR DESCRIPTION
This check also prevented wardens from being able to place markers without moving their mouse when right clicking. This was very confusing for wardens.

Moreover, it is impossible to get a negative value with GetVectorDistance (and it wouldn't be problematic as the radius of the circle is forced to a min&max).